### PR TITLE
[DO NOT MERGE] testing how long the wait is for fetching + apply

### DIFF
--- a/Client/Application/AppDelegate+Experiments.swift
+++ b/Client/Application/AppDelegate+Experiments.swift
@@ -39,7 +39,10 @@ extension AppDelegate {
             log.info("Nimbus: server does not exist")
             options = Experiments.InitializationOptions.normal
         }
-
-        Experiments.intialize(options)
+//        if isFirstRun {
+            Experiments.initializeFirstRun(options)
+//        } else {
+//            Experiments.intialize(options)
+//        }
     }
 }

--- a/Client/Application/AppDelegate+Experiments.swift
+++ b/Client/Application/AppDelegate+Experiments.swift
@@ -10,17 +10,16 @@ import Foundation
 
 extension AppDelegate {
     func initializeExperiments() {
-
         let defaults = UserDefaults.standard
         let nimbusFirstRun = "NimbusFirstRun"
-        let firstRun = defaults.bool(forKey: nimbusFirstRun) != false
+        let isFirstRun = defaults.bool(forKey: nimbusFirstRun) != false
         defaults.set(false, forKey: nimbusFirstRun)
-
+        Experiments.customTargetingAttributes =  ["isFirstRun":  "\(isFirstRun)"]
         let initialExperiments = Bundle.main.url(forResource: "initial_experiments", withExtension: "json")
         let serverURL = Experiments.remoteSettingsURL
         let savedOptions = Experiments.getLocalExperimentData()
         let options: Experiments.InitializationOptions
-        switch (savedOptions, firstRun, initialExperiments, serverURL) {
+        switch (savedOptions, isFirstRun, initialExperiments, serverURL) {
         // QA testing case: experiments come from the Experiments setting screen.
         case (let payload, _, _, _) where payload != nil:
             log.info("Nimbus: Loading from experiments provided by settings screen")

--- a/Client/Experiments/Experiments.swift
+++ b/Client/Experiments/Experiments.swift
@@ -116,6 +116,8 @@ enum Experiments {
     static func usePreviewCollection(storage: UserDefaults = .standard) -> Bool {
         storage.bool(forKey: NIMBUS_USE_PREVIEW_COLLECTION_KEY)
     }
+    
+    static var customTargetingAttributes: [String: String] = [:]
 
     static var serverSettings: NimbusServerSettings? = {
         // If no URL is specified, or it's not valid continue with as if
@@ -152,7 +154,8 @@ enum Experiments {
         // thinks it is.
         let appSettings = NimbusAppSettings(
             appName: nimbusAppName,
-            channel: AppConstants.BuildChannel.nimbusString
+            channel: AppConstants.BuildChannel.nimbusString,
+            customTargetingAttributes: Experiments.customTargetingAttributes
         )
 
         let errorReporter: NimbusErrorReporter = { err in

--- a/Client/Experiments/Experiments.swift
+++ b/Client/Experiments/Experiments.swift
@@ -217,6 +217,37 @@ enum Experiments {
 
         log.info("Nimbus is initializing!")
     }
+    
+    public static func initializeFirstRun(_ options: InitializationOptions) {
+        let nimbus = Experiments.shared
+
+        nimbus.initialize()
+
+        switch options {
+        case .preload(let url): nimbus.setExperimentsLocally(url)
+        case .testing(let payload): nimbus.setExperimentsLocally(payload)
+        default: break /* noop */
+        }
+
+        // on first run, we want to get the experiments from remote settings
+        // first
+        let start = DispatchTime.now()
+        NotificationCenter.default.addObserver(forName: .nimbusExperimentsApplied, object: nil, queue: .main) { _ in
+            let end = DispatchTime.now()
+            let timeElapsed = end.uptimeNanoseconds - start.uptimeNanoseconds
+            let timeInterval = Double(timeElapsed) / 1_000_000_000 // Technically could overflow for long running tests
+            log.info("Time elapsed before available: \(timeInterval) seconds!")
+        }
+        nimbus.fetchExperiments()
+        NotificationCenter.default.addObserver(forName: .nimbusExperimentsFetched, object: nil, queue: .main) { _ in
+            let fetchEnd = DispatchTime.now()
+            let timeElapsed = fetchEnd.uptimeNanoseconds - start.uptimeNanoseconds
+            let timeInterval = Double(timeElapsed) / 1_000_000_000 // Technically could overflow for long running tests
+            log.info("Time elapsed before fetch is done: \(timeInterval) seconds!")
+            nimbus.applyPendingExperiments()
+        }
+        log.info("Nimbus is initializing on First Run!")
+    }
 }
 
 /// Additional methods to allow us to use an application specific `FeatureId` enum.


### PR DESCRIPTION
NOTE : This will not be merged anywhere, it's purely for visibility on testing


On a good network (my own network) running on an `iPhone 12 Pro Max` simulator on xCode, I'm getting a consistent `1.2` to `1.3` seconds of wait time, and the majority `1.1 - 1.2` of it is spent in the fetch (i.e network I/O)

I'll run a couple more runs with a throttled network and record those
